### PR TITLE
Adds support to store and retrieve workflow tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_dynamodb 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ rusoto_dynamodb = "0.42"
 serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_dynamodb = "0.4.1"
+serde_json = "1.0.42"
 uuid = { version = "0.8", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -21,3 +21,31 @@ $ cargo run
 docker build -t regulators .
 docker run -it --rm --publish 9000:8000 --name regulators regulators
 ```
+
+## Details
+
+### POST /regulate API details
+
+The JSON data for `POST /regulate` should be something like this:
+
+```
+{
+    "regulators": [{
+        "name": "Regulators_AcquireLock",
+        "context": {
+            "lock_key": "foo::bar"
+        }
+    }, {
+        "name": "Regulators_CodeReviewVerification",
+        "context": {
+            "repository": "https://github.com/mmerkes/Regulators",
+            "required_approvers": 1
+        }
+    }, {
+        "name": "MyCustomRegulator",
+        "context": {
+            "foo": "bar"
+        }
+    }]
+}
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,12 @@ extern crate rusoto_dynamodb;
 extern crate serde;
 extern crate serde_dynamodb;
 
+use rocket::State;
 use rocket_contrib::json::Json;
 use rusoto_core::Region;
-use rusoto_dynamodb::{DynamoDb, DynamoDbClient, PutItemInput};
+use rusoto_dynamodb::{DynamoDb, DynamoDbClient, AttributeValue, GetItemInput, PutItemInput};
+use serde_json::Value;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -18,26 +21,47 @@ struct Workflow {
     status: String,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct Regulator {
+    name: String,
+    context: HashMap<String, Value>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct WorkflowTask {
+    id: String,
+    workflow_id: String,
+    status: String,
+    regulator: Regulator,
+}
+
 #[derive(Serialize)]
 struct RegulateResponse {
     id: String
 }
 
-#[post("/regulate")]
-fn regulate() -> Json<RegulateResponse> {
+#[derive(Deserialize)]
+struct RegulateData {
+    regulators: Vec<Regulator>,
+}
+
+#[post("/regulate", data = "<data>")]
+fn regulate(data: Json<RegulateData>, ddb: State<DynamoDbClient>) -> Json<RegulateResponse> {
+    let regulators = data.into_inner().regulators;
+
     let workflow_id = Uuid::new_v4();
     let workflow = Workflow {
         id: workflow_id.to_string(),
         status: "InProgress".to_owned(),
     };
-	let client = DynamoDbClient::new(Region::UsEast1);
 
+    // This block could be improved.
     match serde_dynamodb::to_hashmap(&workflow) {
         Ok(workflow_ddb) => {
             let mut put_item_input: PutItemInput = Default::default();
             put_item_input.item = workflow_ddb;
             put_item_input.table_name = "workflows".to_owned();
-            match client.put_item(put_item_input).sync() {
+            match ddb.put_item(put_item_input).sync() {
                 Ok(_output) => {
                 }
                 Err(error) => {
@@ -47,6 +71,40 @@ fn regulate() -> Json<RegulateResponse> {
         },
         Err(err) => {
             println!("{:?}", err);
+        }
+    }
+
+    let workflow_tasks: Vec<WorkflowTask> = regulators.iter().map(|regulator| {
+        WorkflowTask {
+            id: Uuid::new_v4().to_string(),
+            workflow_id: workflow_id.to_string(),
+            status: "InProgress".to_owned(),
+            // Assuredly, this can be done more elegantly.
+            regulator: Regulator {
+                name: regulator.name.clone(),
+                context: regulator.context.clone(),
+            },
+        }
+    }).collect();
+
+    // Batch into a single DDB call.
+    for task in &workflow_tasks {
+        match serde_dynamodb::to_hashmap(&task) {
+            Ok(task_ddb) => {
+                let mut put_item_input: PutItemInput = Default::default();
+                put_item_input.item = task_ddb;
+                put_item_input.table_name = "tasks".to_owned();
+                match ddb.put_item(put_item_input).sync() {
+                    Ok(_output) => {
+                    }
+                    Err(error) => {
+                        println!("Error: {:?}", error);
+                    }
+                }
+            },
+            Err(err) => {
+                println!("{:?}", err);
+            }
         }
     }
 
@@ -65,11 +123,40 @@ fn update_task(workflow: String, task: String) {
 }
 
 #[get("/workflows/<workflow>/tasks/<task>")]
-fn get_task(workflow: String, task: String) -> String {
-	"Returns task information".to_string()
+fn get_task(workflow: String, task: String, ddb: State<DynamoDbClient>) -> Option<Json<WorkflowTask>> {
+    let mut key = HashMap::new();
+    let mut primary_key: AttributeValue = Default::default();
+    primary_key.s = Some(workflow);
+    let mut sort_key: AttributeValue = Default::default();
+    sort_key.s = Some(task);
+    key.insert("workflow_id".to_string(), primary_key);
+    key.insert("id".to_string(), sort_key);
+    let mut get_item_input: GetItemInput = Default::default();
+    get_item_input.key = key;
+    get_item_input.table_name = "tasks".to_string();
+    return match ddb.get_item(get_item_input).sync() {
+        Ok(output) => {
+            match serde_dynamodb::from_hashmap(output.item.unwrap()) {
+                Ok(workflow_task) => {
+                    Some(Json(workflow_task))
+                },
+                Err(err) => {
+                    println!("{:?}", err);
+                    None
+                }
+            }
+        }
+        Err(error) => {
+            println!("Error: {:?}", error);
+            None
+        }
+    };
 }
 
 fn main() {
-    rocket::ignite().mount("/", routes![regulate, get_workflow,
-                           update_task, get_task]).launch();
+    rocket::ignite()
+        .manage(DynamoDbClient::new(Region::UsEast1))
+        .mount("/", routes![regulate, get_workflow,
+                           update_task, get_task])
+        .launch();
 }


### PR DESCRIPTION
The `POST /regulate` API now stores tasks for each regulator in the DB, and you can retrieve the task via the `GET /workflows/:workflow/tasks/:task` API.